### PR TITLE
update README regarding Jupyter Lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,14 @@ Checkout the Inspector code on cori.nersc.gov:
 git clone https://github.com/sbailey/inspector
 ```
 
-Get the full directory path to your home directory at NERSC (this is unfortunately necessary for the next step):
+Generate the URL where you will be able to login to jupyter (this is unfortunately necessary for the next step):
 ```
-echo $HOME
+cd inspector
+echo https://jupyter-dev.nersc.gov/user/${USER}/tree${PWD}
 ```
 
-Login to https://jupyter-dev.nersc.gov/user/USERNAME/tree/HOME substituting "USERNAME" with your NERSC username and "HOME" with the filepath to your home directory in the previous step, e.g.
-https://jupyter-dev.nersc.gov/user/johndoe/tree/global/homes/j/johndoe.
+Copy that URL into a browser window and login with your NERSC username/password.  The URL should be something like
+https://jupyter-dev.nersc.gov/user/johndoe/tree/global/homes/j/johndoe/inspector).
 
 **Note**: inspector is currently not compatible with the newer Jupyter Lab default interface at NERSC, thus requiring the URL messiness above; we're working with NERSC consulting to resolve that.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ If you really want a feature, please consider contributing it.
 * Filtering to individual exposures or tiles
 
 <hr/>
-<bold>Stephen Bailey</bold> Lawrence Berkeley National Lab<br/>
-<bold>Benjamin Weaver</bold> National Optical Astronomy Observatory<br/>
+
+**Stephen Bailey** Lawrence Berkeley National Lab<br/>
+**Benjamin Weaver** National Optical Astronomy Observatory<br/>
 
 Summer 2018

--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ or install any code locally.
 
 It is currently in a standalone package for exploratory development,
 but could be moved into desispec after it matures.
-
 This should be viewed as a technology demonstrator.  Details about the
 interface and implementation can and probably will (should!) change.
 The main point of releasing this package is to provide a functionally useful
 demonstration that bokeh+jupyter+NERSC could work for viewing DESI spectra.
+
+![Inspector Screenshot](screenshot.png)
 
 ## Getting Started
 
@@ -26,13 +27,17 @@ Checkout the Inspector code on cori.nersc.gov:
 git clone https://github.com/sbailey/inspector
 ```
 
-Login at https://jupyter-dev.nersc.gov and navigate to the directory
+Login to https://jupyter-dev.nersc.gov/user/USERNAME/tree/global/homes/s/USERNAME, substituting "USERNAME" with your NERSC username in two places in that URL.
+
+**Note**: inspector is currently not compatible with the newer Jupyter Lab default interface at NERSC, thus requiring the URL messiness above; we're working with NERSC consulting to resolve that.
+
+After logging in with your NERSC username/password, navigate to the directory
 where you cloned the inspector repository.  Click `inspector.ipynb` to
 start the notebook and explore.
 
-Note: Unfortunately jupyter does not save the generated plots in
+**Note**: Unfortunately jupyter does not save the generated plots in
 the notebook itself, so viewing the static notebook on github isn't
-so instructive; you'll need to really start it at NERSC yourself.
+so instructive; you'll really need to start it at NERSC yourself.
 There is a floppy disk (!) save icon on the plot that can be used to
 save the plot if you want to send it to someone else.
 
@@ -52,8 +57,6 @@ save the plot if you want to send it to someone else.
 * Highlight common emission / absorption lines.
 * Buttons for navigating previous/next target
 * Buttons for saving visual inspection results before moving to next target.
-
-![Inspector Screenshot](screenshot.png)
 
 ## What it doesn't do (yet)
 
@@ -75,4 +78,4 @@ If you really want a feature, please consider contributing it.
 **Stephen Bailey** Lawrence Berkeley National Lab<br/>
 **Benjamin Weaver** National Optical Astronomy Observatory<br/>
 
-Spring 2018
+Summer 2018

--- a/README.md
+++ b/README.md
@@ -27,7 +27,13 @@ Checkout the Inspector code on cori.nersc.gov:
 git clone https://github.com/sbailey/inspector
 ```
 
-Login to https://jupyter-dev.nersc.gov/user/USERNAME/tree/global/homes/s/USERNAME, substituting "USERNAME" with your NERSC username in two places in that URL.
+Get the full directory path to your home directory at NERSC (this is unfortunately necessary for the next step):
+```
+echo $HOME
+```
+
+Login to https://jupyter-dev.nersc.gov/user/USERNAME/tree/HOME substituting "USERNAME" with your NERSC username and "HOME" with the filepath to your home directory in the previous step, e.g.
+https://jupyter-dev.nersc.gov/user/johndoe/tree/global/homes/j/johndoe.
 
 **Note**: inspector is currently not compatible with the newer Jupyter Lab default interface at NERSC, thus requiring the URL messiness above; we're working with NERSC consulting to resolve that.
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,8 @@ https://jupyter-dev.nersc.gov/user/johndoe/tree/global/homes/j/johndoe/inspector
 
 **Note**: inspector is currently not compatible with the newer Jupyter Lab default interface at NERSC, thus requiring the URL messiness above; we're working with NERSC consulting to resolve that.
 
-After logging in with your NERSC username/password, navigate to the directory
-where you cloned the inspector repository.  Click `inspector.ipynb` to
-start the notebook and explore.
+The URL generated above should show you a directory file browser of your inspector git checkout (if not, navigate to where you did check it out).
+Click `inspector.ipynb` to start the notebook and explore.
 
 **Note**: Unfortunately jupyter does not save the generated plots in
 the notebook itself, so viewing the static notebook on github isn't

--- a/README.md
+++ b/README.md
@@ -84,5 +84,4 @@ If you really want a feature, please consider contributing it.
 
 **Stephen Bailey** Lawrence Berkeley National Lab<br/>
 **Benjamin Weaver** National Optical Astronomy Observatory<br/>
-
 Summer 2018

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If you really want a feature, please consider contributing it.
 * Filtering to individual exposures or tiles
 
 <hr/>
-**Stephen Bailey** Lawrence Berkeley National Lab<br/>
-**Benjamin Weaver** National Optical Astronomy Observatory<br/>
+<bold>Stephen Bailey</bold> Lawrence Berkeley National Lab<br/>
+<bold>Benjamin Weaver</bold> National Optical Astronomy Observatory<br/>
 
 Summer 2018


### PR DESCRIPTION
This PR updates the README.md for how to use the classic Jupyter interface at NERSC, since the new default Jupyter Lab interface doesn't yet work.

Unfortunately the Help -> Launch Classic Notebook option from the Jupyter Lab interface takes you to the root filesystem, from where it is oddly impossible to navigate back to your home directory without actually just entering it into the the URL, thus the instructions are a bit messy.

@weaverba137 please check whether these seem reasonably clear, and/or directly make updates if you find a simpler way to get the URL for the classic Jupyter interface at your home directory.  When you are satisfied, please merge.

Fixes #10.